### PR TITLE
In challenge format_train_route, there was a duplicated word. Fixed.

### DIFF
--- a/src/test/kotlin/com/igorwojda/list/formattrainroute/desc.md
+++ b/src/test/kotlin/com/igorwojda/list/formattrainroute/desc.md
@@ -6,7 +6,7 @@ Given list of strings representing train station names implement a function whic
 `String`:
 - String always starts with `Train is calling at`
 - If list contains single tran station name then return `Train is calling at stationName`
-- If list contains multiple train station names then return comma separated station names, but pre-last and last names are  sepateted separated by `and`
+- If list contains multiple train station names then return comma separated station names, but pre-last and last names are separated by `and`
 
 [challenge](challenge.kt) | [solution](solution.kt)
 


### PR DESCRIPTION
### Nothing changed to the code & test, just a mistyping fix

Please, kindly accept this request, there was a duplicated word in the description of challenge format_train_route.
