### PR TITLE
list/coins: Fix order of shouldBeEqualTo() params

### DIFF
--- a/src/test/kotlin/com/igorwojda/list/coins/challenge.kt
+++ b/src/test/kotlin/com/igorwojda/list/coins/challenge.kt
@@ -13,41 +13,41 @@ private class Test {
     fun `4 wys`() {
         val actual: Int = getCoins(4, listOf(1, 2, 3))
         val expected = 4
-        expected shouldBeEqualTo actual
+        actual shouldBeEqualTo expected
     }
 
     @Test
     fun `one way`() {
         val actual: Int = getCoins(0, listOf(1, 2))
         val expected = 1
-        expected shouldBeEqualTo actual
+        actual shouldBeEqualTo expected
     }
 
     @Test
     fun `no coins returns 0`() {
         val actual: Int = getCoins(1, listOf())
         val expected = 0
-        expected shouldBeEqualTo actual
+        actual shouldBeEqualTo expected
     }
 
     @Test
     fun `big coins`() {
         val actual: Int = getCoins(5, listOf(25, 50))
         val expected = 0
-        expected shouldBeEqualTo actual
+        actual shouldBeEqualTo expected
     }
 
     @Test
     fun `big amount`() {
         val actual: Int = getCoins(50, listOf(5, 10))
         val expected = 6
-        expected shouldBeEqualTo actual
+        actual shouldBeEqualTo expected
     }
 
     @Test
     fun `a lot of change`() {
         val actual: Int = getCoins(100, listOf(1, 5, 10, 25, 50))
         val expected = 292
-        expected shouldBeEqualTo actual
+        actual shouldBeEqualTo expected
     }
 }


### PR DESCRIPTION
This fixes the misplaced expected and actual values in the error messages.

Before:
```
The following assertion failed:
Expected <1>, actual <4>.
	at com.igorwojda.list.coins.Test.4 wys(challenge.kt:17)
```
After:
```
The following assertion failed:
Expected <4>, actual <1>.
	at com.igorwojda.list.coins.Test.4 wys(challenge.kt:17)
```