### PR TITLE
fix example code in desc.md

### DIFF
--- a/src/test/kotlin/com/igorwojda/integer/fizzbuzz/desc.md
+++ b/src/test/kotlin/com/igorwojda/integer/fizzbuzz/desc.md
@@ -13,6 +13,6 @@ word `Buzz`. For numbers which are multiples of both three and five list should 
 ```kotlin
 fizzBuzz(5) // [1, 2, "Fizz", 4, "Buzz"]
 
-fizzBuzz(16) // [1, 2, "Fizz", 4, "Buzz", 5, "Fizz", 7, 8, "Fizz", "Buzz", 11, "Fizz", 13, 14, "FizzBuzz", 16]
+fizzBuzz(16) // [1, 2, "Fizz", 4, "Buzz", "Fizz", 7, 8, "Fizz", "Buzz", 11, "Fizz", 13, 14, "FizzBuzz", 16]
 ```
 


### PR DESCRIPTION
The description of the challenge does not seem to fit the example.

A multiple of 5 must be replaced by Buzz, but not in the example.