### PR TITLE
Correction to insertAt() in singly linked list solution

### DIFF
--- a/src/test/kotlin/com/igorwojda/linkedlist/singly/base/challenge.kt
+++ b/src/test/kotlin/com/igorwojda/linkedlist/singly/base/challenge.kt
@@ -339,6 +339,14 @@ private class Test {
 //    }
 //
 //    @Test
+//    fun `insert a new node to an empty list when index is out of bounds`() {
+//        SinglyLinkedList<Int>().apply {
+//            insertAt(1, 100)
+//            getAt(0)!!.data shouldBeEqualTo 1
+//        }
+//    }
+//
+//    @Test
 //    fun `sum all the nodes`() {
 //        SinglyLinkedList<Int>().apply {
 //            insertLast(1)

--- a/src/test/kotlin/com/igorwojda/linkedlist/singly/base/solution.kt
+++ b/src/test/kotlin/com/igorwojda/linkedlist/singly/base/solution.kt
@@ -31,13 +31,15 @@ object Solution1 {
             insertAt(data, size)
         }
 
-        fun insertAt(data: E, index: Int) {
+        fun insertAt(item: E, index: Int) {
             if (index == 0) {
-                head = Node(data, head)
+                head = Node(item, head)
             } else {
-                val prevNode = getAt(index - 1) ?: last
-                val node = prevNode?.next
-                prevNode?.next = Node(data, node)
+                val nodeBeforeIndex = getAt(index - 1) ?: last
+                nodeBeforeIndex?.let {
+                    val restOfList = nodeBeforeIndex.next
+                    it.next = Node(item, restOfList)
+                } ?: insertLast(item)
             }
         }
 

--- a/src/test/kotlin/com/igorwojda/linkedlist/singly/base/solution.kt
+++ b/src/test/kotlin/com/igorwojda/linkedlist/singly/base/solution.kt
@@ -31,15 +31,15 @@ object Solution1 {
             insertAt(data, size)
         }
 
-        fun insertAt(item: E, index: Int) {
+        fun insertAt(data: E, index: Int) {
             if (index == 0) {
-                head = Node(item, head)
+                head = Node(data, head)
             } else {
                 val nodeBeforeIndex = getAt(index - 1) ?: last
                 nodeBeforeIndex?.let {
                     val restOfList = nodeBeforeIndex.next
-                    it.next = Node(item, restOfList)
-                } ?: insertLast(item)
+                    it.next = Node(data, restOfList)
+                } ?: insertLast(data)
             }
         }
 


### PR DESCRIPTION
I think there is a bug in the solution for implementing a singly linked list when an attempt is made to insert a node to an empty list using an index that is out of bounds. Fixed the issue and added a test case.
