### PR TITLE
Fix order of expected elements in smallest elements test

### DIFF
--- a/src/test/kotlin/com/igorwojda/list/smallestelements/Challenge.kt
+++ b/src/test/kotlin/com/igorwojda/list/smallestelements/Challenge.kt
@@ -26,7 +26,7 @@ private class Test {
     fun `2 smallest elements`() {
         val list = listOf(5, 1, 3)
 
-        smallestElements(list, 2) shouldBeEqualTo listOf(3, 1)
+        smallestElements(list, 2) shouldBeEqualTo listOf(1, 3)
     }
 
     @Test


### PR DESCRIPTION
This PR fixes the order of elements in the "2 smallest elements" test case to maintain the original sequence order.

Changed:
smallestElements(list, 2) shouldBeEqualTo listOf(3, 1)
To:
smallestElements(list, 2) shouldBeEqualTo listOf(1, 3)

The order [1, 3] is correct because it preserves the order these elements appeared in the original list [5, 1, 3].

Note: The build is failing due to missing Test classes in other challenge files (anycallback, advancedlru). These issues should be addressed separately as they are unrelated to this specific test fix.